### PR TITLE
Fix zero division error in test_script

### DIFF
--- a/test_script.py
+++ b/test_script.py
@@ -1,6 +1,8 @@
 # test_script.py
 
 def divide(a, b):
+    if b == 0:
+        raise ValueError("Cannot divide by zero")
     return a / b
 
-print(divide(10, 0))
+print(divide(10, 2))


### PR DESCRIPTION
## Summary
- handle division by zero in `divide`
- change example call to use non-zero denominator

## Testing
- `python test_script.py`

------
https://chatgpt.com/codex/tasks/task_e_68468d62cf988331b0e83419bd0eea26