### PR TITLE
Add RAG proof of concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # codex-test
+
+This repository contains example code used for testing Codex features.
+
+## RAG Proof of Concept
+
+`rag_poc.py` is an interactive script demonstrating a simple Retrieval Augmented
+Generation (RAG) workflow. It can:
+
+1. Read a PDF file.
+2. Split the text into overlapping chunks.
+3. Convert those chunks into embeddings with Sentence Transformers.
+4. Index the embeddings using FAISS.
+5. Accept user questions and retrieve the most relevant chunks.
+6. Use a Hugging Face question-answering model to generate an answer from the
+   retrieved context.
+
+### Usage
+
+```bash
+pip install PyPDF2 sentence-transformers faiss-cpu transformers
+python rag_poc.py path/to/document.pdf
+```
+
+Then type your questions at the prompt. Enter `quit` to exit.

--- a/rag_poc.py
+++ b/rag_poc.py
@@ -1,0 +1,73 @@
+import sys
+import PyPDF2
+from sentence_transformers import SentenceTransformer
+from transformers import pipeline
+import faiss
+import numpy as np
+
+
+def read_pdf(path):
+    """Load a PDF file and return its text content."""
+    reader = PyPDF2.PdfReader(path)
+    text = ""
+    for page in reader.pages:
+        page_text = page.extract_text()
+        if page_text:
+            text += page_text + "\n"
+    return text
+
+
+def chunk_text(text, chunk_size=200, overlap=50):
+    """Split text into overlapping chunks."""
+    words = text.split()
+    chunks = []
+    start = 0
+    while start < len(words):
+        end = start + chunk_size
+        chunk = " ".join(words[start:end])
+        chunks.append(chunk)
+        start += chunk_size - overlap
+    return chunks
+
+
+def build_index(chunks, model):
+    """Create FAISS index from text chunks."""
+    embeddings = model.encode(chunks, convert_to_numpy=True)
+    dim = embeddings.shape[1]
+    index = faiss.IndexFlatL2(dim)
+    index.add(embeddings)
+    return index, embeddings
+
+
+def retrieve(query, model, index, chunks, top_k=3):
+    """Retrieve top_k relevant chunks for the query."""
+    q_embed = model.encode([query], convert_to_numpy=True)
+    distances, indices = index.search(q_embed, top_k)
+    return [chunks[i] for i in indices[0]]
+
+
+def main(pdf_path):
+    text = read_pdf(pdf_path)
+    if not text:
+        print("No text extracted from PDF.")
+        return
+    chunks = chunk_text(text)
+    embedder = SentenceTransformer('all-MiniLM-L6-v2')
+    index, _ = build_index(chunks, embedder)
+    qa = pipeline('question-answering', model='distilbert-base-cased-distilled-squad')
+
+    print("Loaded PDF. Ask questions (type 'quit' to exit).")
+    while True:
+        question = input('Question: ').strip()
+        if question.lower() in {'quit', 'exit'}:
+            break
+        context = "\n".join(retrieve(question, embedder, index, chunks))
+        result = qa(question=question, context=context)
+        print(f"Answer: {result['answer']}")
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print('Usage: python rag_poc.py path/to/file.pdf')
+    else:
+        main(sys.argv[1])


### PR DESCRIPTION
## Summary
- add `rag_poc.py` implementing a minimal RAG workflow
- document usage in README

## Testing
- `python -m py_compile rag_poc.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f8454f08833194e47cc43acd6313